### PR TITLE
Reestructure api card api endpoints for better extensibility

### DIFF
--- a/src/utils/string/parseStringToNumber.ts
+++ b/src/utils/string/parseStringToNumber.ts
@@ -1,0 +1,5 @@
+export const parseStringToNumber = (value: string | null): number | null => {
+  if (!value) return null;
+  const parsed = parseInt(value);
+  return isNaN(parsed) ? null : parsed;
+};

--- a/src/utils/string/parseStringToNumber.ts
+++ b/src/utils/string/parseStringToNumber.ts
@@ -1,5 +1,5 @@
 export const parseStringToNumber = (value: string | null): number | null => {
   if (!value) return null;
-  const parsed = parseInt(value);
+  const parsed = parseInt(value, 10);
   return isNaN(parsed) ? null : parsed;
 };


### PR DESCRIPTION
The new structure considers the types of the cards given that each type might respond back with a different data structure and might cover different use-cases.

For situations where the user might want to query many types and is indifferent on the possible type differences it is still possible to interpolate the urls to easily switch between the types. 

The main trade-off at the moment is that it is not trivial to easily fetch all card types in a single query. This tradeoff is considered acceptable at the moment given that we don't foresee the need for this use-case plus it is trivial to implement it by itself.