### PR TITLE
Fetch and create more cards when review is complete

### DIFF
--- a/src/app/api/card/types/sentence/[userId]/route.ts
+++ b/src/app/api/card/types/sentence/[userId]/route.ts
@@ -1,5 +1,6 @@
 import { CARD_TYPES } from "@/constants/cards";
 import prisma from "@/database/client";
+import { generateCardsForUser } from "@/lib/cards/generateCardsForUser";
 import { parseStringToNumber } from "@/utils/string/parseStringToNumber";
 import { NextRequest } from "next/server";
 
@@ -81,9 +82,10 @@ const getLatestSentenceCards = async ({
     // This breaks the idempotency of the operation
     // However it is a calculated measure to avoid having other solutions
     // that would have been overly complicated for this point in time.
-    if (cardsLeftForReview <= 5) {
+    if (cardsLeftForReview <= 10) {
       // Fire-and-forget: generateCardsForUser is intentionally not awaited
       // because it performs a background task that does not affect the response.
+      generateCardsForUser(userId, "da");
     }
 
     return cards;

--- a/src/app/sentence/page.tsx
+++ b/src/app/sentence/page.tsx
@@ -14,7 +14,7 @@ export default function Page() {
   const [selectedSentenceIdx, setSelectedSentenceIdx] = useState(0);
   const [selectedCardId, setSelectedCardId] = useState<string | null>(null);
 
-  const { data, isLoading } = useQuery({
+  const { data, isLoading, refetch } = useQuery({
     queryKey: ["cards"],
     queryFn: () =>
       apiFetcher<Array<CardType>>(
@@ -39,12 +39,18 @@ export default function Page() {
     }
   }, [data, selectedSentenceIdx]);
 
-  const handleNextSentence = () => {
+  const handleNextSentence = async () => {
     if (!data?.length) return;
 
     if (selectedSentenceIdx < data?.length - 1) {
       setSelectedSentenceIdx((prev) => prev + 1);
     }
+
+    if (selectedSentenceIdx === data?.length - 1) {
+      await refetch();
+      setSelectedSentenceIdx(0);
+    }
+
     setShowDefinition(false);
     return;
   };


### PR DESCRIPTION
This pull request introduces changes to improve card generation logic, enhance user experience on the sentence page, and fix potential issues with card handling. The most important updates include modifying the card generation threshold, adding a background task for card generation, and refining the behavior when navigating sentences.

### Card generation logic updates:
* `src/app/api/card/types/sentence/[userId]/route.ts`: Increased the threshold for triggering card generation from 5 to 10 cards left for review and added a background call to `generateCardsForUser` to preemptively generate cards when the threshold is met. ([src/app/api/card/types/sentence/[userId]/route.tsL84-R88](diffhunk://#diff-0355093b89c0f3fe0d16e6f34e38a67f4aa81f67e45de6cbbfb14462dba193ebL84-R88))

### Sentence page enhancements:
* [`src/app/sentence/page.tsx`](diffhunk://#diff-d08705e1199a623d9d3f901439c14155e00f7c0caa48c622f8be97e8dfaefd39L17-R17): Added `refetch` to the `useQuery` hook to allow re-fetching data when needed.
* [`src/app/sentence/page.tsx`](diffhunk://#diff-d08705e1199a623d9d3f901439c14155e00f7c0caa48c622f8be97e8dfaefd39L42-R53): Updated the `handleNextSentence` function to refetch cards and reset the sentence index when the user reaches the last sentence, ensuring a seamless experience.