### PR TITLE
Fix - words should start with original language before translation

### DIFF
--- a/src/app/sentence/page.tsx
+++ b/src/app/sentence/page.tsx
@@ -218,7 +218,8 @@ const Definition: React.FC<DefinitionProps> = ({
         <div className={"flex flex-col w-full gap-small"}>
           {words.map((w) => {
             return (
-              <div key={w.word} className={"flex flex-col gap-xSmall"}>
+              <div key={w.word} className={"flex flex-col"}>
+                <p className={"font-medium capitalize"}>{w.word}: </p>
                 <p>{w.definition}</p>
               </div>
             );

--- a/src/prompts/generate-sentences-prompt.md
+++ b/src/prompts/generate-sentences-prompt.md
@@ -4,25 +4,26 @@ TASK:
 Generate an array with {{amount_number}} unique, creative sentences in {{language}} that would be useful for language learners.
 
 REQUIREMENTS:
-- Use these specific sentence structures: {{structure_1}} and {{structure_2}}
-- Difficulty level: {{level}} (1-4)
-- Context: {{context}}
+- Use these specific sentence structures: {{structure_1}} and {{structure_2}}.
+- Difficulty level: {{level}} (1-4).
+- Context: {{context}}.
 - Topic focus: {{topic_1}} and {{topic_2}}!
 
 CONSTRAINTS:
-- Sentences must be realistic, practical examples of everyday communication
-- Use natural, contemporary language (not textbook examples)
-- Include diverse vocabulary appropriate to the difficulty level
-- MINIMIZE SUSTAINABILITY RELATED TOPICS
+- Sentences must be realistic, practical examples of everyday communication.
+- Use natural, contemporary language (not textbook examples).
+- Include diverse vocabulary appropriate to the difficulty level.
+- MINIMIZE SUSTAINABILITY RELATED TOPICS.
+- Make sure to follow the requirements described above.
 
 AVOID SIMILARITY:
-- Avoid repeating verbs, nouns or patterns from the examples above
+- Avoid repeating verbs, nouns or patterns from the examples above.
 
 FOR EACH SENTENCE PROVIDE:
 1. The sentence in {{language}}
-2. Words: translation with brief explanations:
-   - Include the translation of each word
-   - Add a short explanation of its meaning in context
-   - Note any alternate meanings or nuances
-   - Mention any grammatical considerations (gender, conjugation, etc.). Word-by-word translation
-3. translation
+2. Words: ALL WORDS from the sentence with brief explanations:
+   - Start with the word itself in {{language}}.
+   - Include the translation of each word.
+   - Add a short explanation of its meaning in context.
+   - Note any alternate meanings or nuances.
+   - Mention any grammatical considerations (gender, conjugation, etc.). Word-by-word translation.


### PR DESCRIPTION
This pull request includes updates to improve the user interface for displaying word definitions and refines the prompt instructions for generating sentences. The most important changes focus on enhancing readability and clarity for both users and developers.

closes #40 

### User Interface Improvements:
* [`src/app/sentence/page.tsx`](diffhunk://#diff-d08705e1199a623d9d3f901439c14155e00f7c0caa48c622f8be97e8dfaefd39L221-R222): Updated the word definition display to include a bolded, capitalized word label (`<p className={"font-medium capitalize"}>{w.word}: </p>`) for better readability.

### Prompt Instruction Refinements:
* [`src/prompts/generate-sentences-prompt.md`](diffhunk://#diff-68a3ea384f2fc3183e3d4c1cc2a95131ca6963b5fc8365a7dbb466cb4f73c6c6L7-R29): Improved clarity and consistency in the sentence generation instructions by standardizing punctuation, adding a new requirement to follow all described instructions, and enhancing the explanation structure for word translations.