### PR TITLE
Feat: modifying the prisma schema so that we connect to the new database

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -9,8 +9,9 @@ generator client {
 }
 
 datasource db {
-  provider = "postgresql"
-  url      = env("DATABASE_URL")
+  provider  = "postgresql"
+  url       = env("DATABASE_URL")
+  directUrl = env("DIRECT_URL")
 }
 
 model User {


### PR DESCRIPTION
This pull request introduces a small but significant change to the Prisma schema configuration. The change adds a `directUrl` field to the `datasource db` block, enabling the use of a direct connection URL for the database.

* [`prisma/schema.prisma`](diffhunk://#diff-5b443964f4f3a611682db8f7e02177b0a8c632b2039e2bd5e4dd7347815c565cR14): Added the `directUrl` field to the `datasource db` block, which allows specifying a direct database connection URL via the `DIRECT_URL` environment variable.